### PR TITLE
Review form refactor

### DIFF
--- a/src/ts/__tests__/app/review-form/__snapshots__/index.test.tsx.snap
+++ b/src/ts/__tests__/app/review-form/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,16 @@
 
 exports[`ReviewForm should render the review form fields with the addReview action passed to it 1`] = `
 <div
-  addReview={[MockFunction]}
+  addReview={[Function]}
+  formState={
+    Object {
+      "comment": "",
+      "email": "",
+      "name": "",
+      "rating": 0,
+    }
+  }
+  updateFormState={[Function]}
 >
   ReviewFormFields
 </div>

--- a/src/ts/__tests__/app/review-form/__snapshots__/review-form-fields.test.tsx.snap
+++ b/src/ts/__tests__/app/review-form/__snapshots__/review-form-fields.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ReviewFormFields should render the fields for the review form 1`] = `
 <form
   className="review-form"
-  onSubmit={[Function]}
+  onSubmit={[MockFunction]}
 >
   <label
     htmlFor="review-form-name"
@@ -13,10 +13,10 @@ exports[`ReviewFormFields should render the fields for the review form 1`] = `
   <input
     id="review-form-name"
     name="name"
-    onChange={[Function]}
+    onChange={[MockFunction]}
     required={true}
     type="text"
-    value=""
+    value="fake name"
   />
   <label
     htmlFor="review-form-email"
@@ -26,10 +26,10 @@ exports[`ReviewFormFields should render the fields for the review form 1`] = `
   <input
     id="review-form-email"
     name="email"
-    onChange={[Function]}
+    onChange={[MockFunction]}
     required={true}
     type="text"
-    value=""
+    value="fake email"
   />
   <label
     htmlFor="review-form-rating"
@@ -41,10 +41,10 @@ exports[`ReviewFormFields should render the fields for the review form 1`] = `
     max={5}
     min={1}
     name="rating"
-    onChange={[Function]}
+    onChange={[MockFunction]}
     required={true}
     type="number"
-    value={0}
+    value={5}
   />
   <label
     htmlFor="review-form-comment"
@@ -54,9 +54,9 @@ exports[`ReviewFormFields should render the fields for the review form 1`] = `
   <input
     id="review-form-comment"
     name="comment"
-    onChange={[Function]}
+    onChange={[MockFunction]}
     required={true}
-    value=""
+    value="fake comment"
   />
   <input
     className="button"

--- a/src/ts/__tests__/app/review-form/review-form-fields.test.tsx
+++ b/src/ts/__tests__/app/review-form/review-form-fields.test.tsx
@@ -1,21 +1,39 @@
 import { mount } from "enzyme";
 import React from "react";
 import renderer from "react-test-renderer";
+import { REVIEW_FORM_FIELD_IDS } from "^/app/review-form/constants";
 
 import { ReviewFormFields } from "^/app/review-form/review-form-fields";
+import { FAKE_REVIEW } from "^/__tests__/__helpers__/fake-review";
 
 describe("ReviewFormFields", () => {
+  const commonProps = {
+    addReview: jest.fn(),
+    updateFormState: jest.fn(),
+    formState: FAKE_REVIEW,
+  };
   it("should render the fields for the review form", () => {
     const reviewFormFields = renderer.create(
-      <ReviewFormFields addReview={jest.fn()} />
+      <ReviewFormFields {...commonProps} />
     );
     expect(reviewFormFields).toMatchSnapshot();
   });
 
   it("should call the addReview action when the form is submitted", () => {
     const addReview = jest.fn().mockReturnValue(Promise.resolve());
-    const reviewFormFields = mount(<ReviewFormFields addReview={addReview} />);
+    const reviewFormFields = mount(
+      <ReviewFormFields {...commonProps} addReview={addReview} />
+    );
     reviewFormFields.find(".review-form").simulate("submit");
     expect(addReview).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call the updateFormState action when a field is updated", () => {
+    const updateFormState = jest.fn().mockReturnValue(Promise.resolve());
+    const reviewFormFields = mount(
+      <ReviewFormFields {...commonProps} updateFormState={updateFormState} />
+    );
+    reviewFormFields.find(`#${REVIEW_FORM_FIELD_IDS.name}`).simulate("change");
+    expect(updateFormState).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ts/app/review-form/index.tsx
+++ b/src/ts/app/review-form/index.tsx
@@ -14,10 +14,9 @@ export const ReviewForm: React.FunctionComponent<Props> = React.memo(
     const [values, setValues] = useState(defaultValues);
 
     const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      const targetName = event.target.name;
-      const targetValue = event.target.value;
+      const { name, value } = event.target;
 
-      setValues((values) => ({ ...values, [targetName]: targetValue }));
+      setValues((values) => ({ ...values, [name]: value }));
     };
 
     const onAddReview = (event: React.FormEvent<HTMLFormElement>) => {

--- a/src/ts/app/review-form/index.tsx
+++ b/src/ts/app/review-form/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { connect } from "react-redux";
 
 import { addReview } from "./actions";
@@ -10,7 +10,29 @@ type Props = {
 
 export const ReviewForm: React.FunctionComponent<Props> = React.memo(
   (props) => {
-    return <ReviewFormFields addReview={props.addReview} />;
+    const defaultValues = { name: "", email: "", rating: 0, comment: "" };
+    const [values, setValues] = useState(defaultValues);
+
+    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const targetName = event.target.name;
+      const targetValue = event.target.value;
+
+      setValues((values) => ({ ...values, [targetName]: targetValue }));
+    };
+
+    const onAddReview = (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      props.addReview(values);
+      setValues(() => defaultValues);
+    };
+
+    return (
+      <ReviewFormFields
+        addReview={onAddReview}
+        updateFormState={handleInputChange}
+        formState={values}
+      />
+    );
   }
 );
 

--- a/src/ts/app/review-form/review-form-fields.tsx
+++ b/src/ts/app/review-form/review-form-fields.tsx
@@ -1,43 +1,31 @@
-import React, { useState } from "react";
+import React from "react";
 
-import { Review } from "^/common/types";
 import {
   MAXIMUM_REVIEW_RATING,
   MINIMUM_REVIEW_RATING,
   REVIEW_FORM_FIELD_IDS,
 } from "./constants";
+import { FormState } from "./types";
 
 type Props = {
-  addReview: (newReview: Review) => void;
+  addReview: (event: React.FormEvent<HTMLFormElement>) => void;
+  updateFormState: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  formState: FormState;
 };
 
 export const ReviewFormFields: React.FunctionComponent<Props> = React.memo(
   (props) => {
-    const defaultValues = { name: "", email: "", rating: 0, comment: "" };
-    const [values, setValues] = useState(defaultValues);
-
-    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      const targetName = event.target.name;
-      const targetValue = event.target.value;
-
-      setValues((values) => ({ ...values, [targetName]: targetValue }));
-    };
-
-    const onAddReview = (event: React.FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      props.addReview(values);
-      setValues(() => defaultValues);
-    };
+    const { name, email, rating, comment } = props.formState;
 
     return (
-      <form className="review-form" onSubmit={onAddReview}>
+      <form className="review-form" onSubmit={props.addReview}>
         <label htmlFor={REVIEW_FORM_FIELD_IDS.name}>Name</label>
         <input
           id={REVIEW_FORM_FIELD_IDS.name}
           type="text"
           name="name"
-          value={values.name}
-          onChange={handleInputChange}
+          value={name}
+          onChange={props.updateFormState}
           required
         />
         <label htmlFor={REVIEW_FORM_FIELD_IDS.email}>Email</label>
@@ -45,8 +33,8 @@ export const ReviewFormFields: React.FunctionComponent<Props> = React.memo(
           id={REVIEW_FORM_FIELD_IDS.email}
           type="text"
           name="email"
-          value={values.email}
-          onChange={handleInputChange}
+          value={email}
+          onChange={props.updateFormState}
           required
         />
         <label htmlFor={REVIEW_FORM_FIELD_IDS.rating}>Rating</label>
@@ -54,8 +42,8 @@ export const ReviewFormFields: React.FunctionComponent<Props> = React.memo(
           type="number"
           id={REVIEW_FORM_FIELD_IDS.rating}
           name="rating"
-          value={values.rating}
-          onChange={handleInputChange}
+          value={rating}
+          onChange={props.updateFormState}
           required
           min={MINIMUM_REVIEW_RATING}
           max={MAXIMUM_REVIEW_RATING}
@@ -64,8 +52,8 @@ export const ReviewFormFields: React.FunctionComponent<Props> = React.memo(
         <input
           id={REVIEW_FORM_FIELD_IDS.comment}
           name="comment"
-          value={values.comment}
-          onChange={handleInputChange}
+          value={comment}
+          onChange={props.updateFormState}
           required
         />
         <input className="button" type="submit" value="Submit" />

--- a/src/ts/app/review-form/types.ts
+++ b/src/ts/app/review-form/types.ts
@@ -5,3 +5,10 @@ export type AddReviewAction = {
   type: typeof ADD_REVIEW;
   payload: Review;
 };
+
+export type FormState = {
+  name: string;
+  email: string;
+  rating: number;
+  comment: string;
+};


### PR DESCRIPTION
### Description

Minor refactoring for review form component logic.
- Move state handing logic to outer form component and pass them to `ReviewFormFields` as callback functions.
- Add `commonProps` object to `ReviewFormFields` tests file to avoid needless repetition of component props.